### PR TITLE
Implemented user cart workers

### DIFF
--- a/lib/ex_cashier.ex
+++ b/lib/ex_cashier.ex
@@ -1,18 +1,78 @@
 defmodule ExCashier do
   @moduledoc """
-  Documentation for `ExCashier`.
+  Main module for the `ExCashier` app!
+
+  It contains the functions needed to test the application.
   """
+  require Logger
+
+  alias ExCashier.{UserCart, UserCartRegistry, UserCartSupervisor}
 
   @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> ExCashier.hello()
-      :world
-
+  Starts a new user cart process and registers it to the user cart registry.
   """
-  def hello do
-    :world
+  @spec start_user_cart(binary()) :: {:ok, pid()} | {:error, {:already_started, pid()}} | :error
+  def start_user_cart(user_identifier) when is_binary(user_identifier) do
+    registry_name = {:via, Registry, {UserCartRegistry, user_identifier}}
+
+    DynamicSupervisor.start_child(UserCartSupervisor, {UserCart, name: registry_name})
+  end
+
+  def start_user_cart(_user_identifier) do
+    Logger.error("User identifiers must be strings")
+    :error
+  end
+
+  @doc """
+  Adds an item to the user's cart.
+  """
+  @spec add_item(binary(), binary()) :: :ok | {:error, :not_found} | :error
+  def add_item(user_identifier, item_identifier)
+      when is_binary(user_identifier) and is_binary(item_identifier) do
+    case lookup_user_cart(user_identifier) do
+      {:ok, pid} ->
+        Logger.info("Added item #{item_identifier} to user #{user_identifier}.")
+        GenServer.cast(pid, {:add_item, item_identifier})
+
+      {:error, :not_found} ->
+        Logger.error("User #{user_identifier} not found.")
+        {:error, :not_found}
+    end
+  end
+
+  def add_item(_user_identifier, _item_identifier) do
+    Logger.error("User and item identifiers must be strings")
+    :error
+  end
+
+  @doc """
+  Returns a user's cart.
+  """
+  @spec get_user_cart(binary()) ::
+          %{user_id: binary(), items: map()} | {:error, :not_found} | :error
+  def get_user_cart(user_identifier) when is_binary(user_identifier) do
+    case lookup_user_cart(user_identifier) do
+      {:ok, pid} -> GenServer.call(pid, :get_cart)
+      {:error, :not_found} -> {:error, :not_found}
+    end
+  end
+
+  def get_user_cart(_user_identifier) do
+    Logger.error("User and item identifiers must be strings")
+    :error
+  end
+
+  # Returns the PID of a user's cart.
+  @spec lookup_user_cart(binary()) :: {:ok, pid()} | {:error, :not_found} | :error
+  defp lookup_user_cart(user_identifier) when is_binary(user_identifier) do
+    case Registry.lookup(ExCashier.UserCartRegistry, user_identifier) do
+      [{pid, _}] -> {:ok, pid}
+      _ -> {:error, :not_found}
+    end
+  end
+
+  defp lookup_user_cart(_user_identifier) do
+    Logger.error("User identifiers must be strings")
+    :error
   end
 end

--- a/lib/ex_cashier/application.ex
+++ b/lib/ex_cashier/application.ex
@@ -10,6 +10,8 @@ defmodule ExCashier.Application do
     children = [
       # Starts a worker by calling: ExCashier.Worker.start_link(arg)
       # {ExCashier.Worker, arg}
+      {DynamicSupervisor, strategy: :one_for_one, name: ExCashier.UserCartSupervisor},
+      {Registry, keys: :unique, name: ExCashier.UserCartRegistry}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/ex_cashier/user_cart.ex
+++ b/lib/ex_cashier/user_cart.ex
@@ -1,0 +1,39 @@
+defmodule ExCashier.UserCart do
+  @moduledoc """
+  This module defines a user cart process.
+
+  It also contains the needed handlers to operate with it.
+  """
+  use GenServer
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, nil, opts)
+  end
+
+  @impl true
+  def init(_) do
+    {:ok, %{user_id: nil, items: %{}}}
+  end
+
+  @impl true
+  def handle_call(:get_cart, _from, state) do
+    {:reply, state.items, state}
+  end
+
+  @impl true
+  def handle_cast({:add_item, item_id}, state) do
+    {:noreply, %{state | items: add_item(state.items, item_id)}}
+  end
+
+  # Adds an new item to the current item list (with quantity 1)
+  # or updates the current quantity of it (sums 1)
+  defp add_item(items_map, new_item) do
+    case Map.get(items_map, new_item) do
+      nil ->
+        Map.put(items_map, new_item, %{quantity: 1})
+
+      %{quantity: qty} = item ->
+        Map.put(items_map, new_item, %{item | quantity: qty + 1})
+    end
+  end
+end

--- a/test/ex_cashier_test.exs
+++ b/test/ex_cashier_test.exs
@@ -1,8 +1,81 @@
 defmodule ExCashierTest do
-  use ExUnit.Case
-  doctest ExCashier
+  use ExUnit.Case, async: true
+  # This will hide logs in the console when testing
+  @moduletag :capture_log
 
-  test "greets the world" do
-    assert ExCashier.hello() == :world
+  @valid_user_identifier "1234abcd"
+  @invalid_user_identifier %{user: "identifier"}
+  @valid_item_identifier "item1"
+  @invalid_item_identifier [item: 1]
+  describe "start_user_cart/1" do
+    setup :clean_up_carts
+
+    test "Starts a user cart when the user identifier is valid" do
+      assert {:ok, _pid} = ExCashier.start_user_cart(@valid_user_identifier)
+    end
+
+    test "Fails to start a user cart when the user has already a working cart" do
+      {:ok, _pid} = ExCashier.start_user_cart(@valid_user_identifier)
+
+      assert {:error, {:already_started, _pid}} =
+               ExCashier.start_user_cart(@valid_user_identifier)
+    end
+
+    test "Fails to start a user cart if the user identifier is invalid" do
+      assert :error = ExCashier.start_user_cart(@invalid_user_identifier)
+    end
   end
+
+  describe "add_item/2" do
+    setup :clean_up_carts
+
+    test "Adds an item to the user's cart if the user exists and the item is valid" do
+      {:ok, _pid} = ExCashier.start_user_cart(@valid_user_identifier)
+      assert :ok = ExCashier.add_item(@valid_user_identifier, @valid_item_identifier)
+
+      assert %{@valid_item_identifier => %{quantity: 1}} =
+               ExCashier.get_user_cart(@valid_user_identifier)
+    end
+
+    test "Fails to add an item if the cart does not exist" do
+      assert {:error, :not_found} =
+               ExCashier.add_item(@valid_user_identifier, @valid_item_identifier)
+    end
+
+    test "Fails to add an item if any of ther parameters is not valid" do
+      assert :error = ExCashier.add_item(@invalid_user_identifier, @valid_item_identifier)
+      assert :error = ExCashier.add_item(@valid_user_identifier, @invalid_item_identifier)
+    end
+  end
+
+  describe "get_user_cart" do
+    setup :clean_up_carts
+
+    test "Returns an empty cart from a new valid user" do
+      {:ok, _pid} = ExCashier.start_user_cart(@valid_user_identifier)
+      assert %{} = ExCashier.get_user_cart(@valid_user_identifier)
+    end
+
+    test "Returns a non-empty cart from a valid user" do
+      {:ok, _pid} = ExCashier.start_user_cart(@valid_user_identifier)
+      assert :ok = ExCashier.add_item(@valid_user_identifier, @valid_item_identifier)
+
+      assert %{@valid_item_identifier => %{quantity: 1}} =
+               ExCashier.get_user_cart(@valid_user_identifier)
+    end
+
+    test "Returns an error if the user identifier is not valid" do
+      assert :error = ExCashier.get_user_cart(@invalid_user_identifier)
+    end
+  end
+
+  defp clean_up_carts(_) do
+    on_exit(fn ->
+      DynamicSupervisor.which_children(ExCashier.UserCartSupervisor)
+      |> Enum.map(&terminate_children(&1))
+    end)
+  end
+
+  defp terminate_children({_, pid, :worker, [ExCashier.UserCart]}),
+    do: DynamicSupervisor.terminate_child(ExCashier.UserCartSupervisor, pid)
 end


### PR DESCRIPTION
We have added the ability to create new user carts and get them.

When we call the `ExCashier.start_user_cart/1` function, we are creating a new user cart. This, as it's a supervised process, will have an internal state where we will store the user's id and all the items added to its cart.

We also have two more functions:

- `ExCashier.add_item/2` - which allows us to add an item to the user's cart
- `ExCashier.get_cart/1` - that will return a user's cart

Notes:

- Added restriction for the user and item identifiers to be **strings**
- All the user cart processes are registered under the user identifier in the `ExCashier.UserCartRegistry`
- The previous restricts the number of carts per user to 1
- Added tests for the mentioned features
- Added some simple documentation and specs